### PR TITLE
DDCNLS-445: Adds play.crypto.secret to application.conf.

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,7 @@ application.router = prod.Routes
 ers-file-validator-timeout-seconds = 70
 play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
 play.http.requestHandler = "play.api.http.GlobalSettingsHttpRequestHandler"
+play.crypto.secret = "URctDfU>nQhuxwGW4@WWEwD=xAFVN8VRQJWsmy>2ZDMoa2Xje5tp;7ofJ3FVolXG"
 
 # Metrics plugin settings - graphite reporting is configured on a per env basis
 metrics {


### PR DESCRIPTION
Should fix:

```
2017-02-15 16:49:41,513 level=[ERROR] logger=[play.api.libs.crypto.CryptoConfigParser] thread=[main] rid=[]
                user=[] message=[The application secret has not been set, and we are in prod mode. Your application is not secure.] 
```

when started via service manager.
