### PR TITLE
DDCE-5059: Removing dependency on Joda in favour of java.time library.

### DIFF
--- a/app/services/audit/AuditService.scala
+++ b/app/services/audit/AuditService.scala
@@ -16,13 +16,14 @@
 
 package services.audit
 
-import org.joda.time.DateTime
 import play.api.mvc.{Request, Session}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.model.DataEvent
+
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.play.audit.DefaultAuditConnector
 
+import java.time.ZonedDateTime
 import scala.concurrent.ExecutionContext
 
 @Singleton
@@ -46,6 +47,6 @@ class AuditService @Inject()(auditConnector: DefaultAuditConnector,
       hc.otherHeaders.toMap ++
       Map("dateTime" ->  getDateTime.toString)
 
-  protected def getDateTime = new DateTime
+  protected def getDateTime = ZonedDateTime.now()
 
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,6 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "com.lightbend.akka"     %% "akka-stream-alpakka-csv"    % "4.0.0",
-    "com.typesafe.play"      %% "play-json-joda"             % "2.10.3",
     "com.typesafe.akka"      %% "akka-stream"                % akkaVersion,
     "com.typesafe.akka"      %% "akka-slf4j"                 % akkaVersion,
     "com.typesafe.akka"      %% "akka-protobuf"              % akkaVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.15.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"      % "3.19.0")
 addSbtPlugin("com.github.gseitz"    % "sbt-release"         % "1.0.10")
 addSbtPlugin("com.typesafe.play"    % "sbt-plugin"          % "2.8.21")
 addSbtPlugin("org.scoverage"        % "sbt-scoverage"       % "2.0.9")

--- a/test/connectors/ERSFileValidatorConnectorSpec.scala
+++ b/test/connectors/ERSFileValidatorConnectorSpec.scala
@@ -20,7 +20,6 @@ import akka.stream.Materializer
 import config.ApplicationConfig
 import models._
 import models.upscan.UpscanCallback
-import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, eq => argEq}
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, EitherValues}
@@ -41,6 +40,8 @@ import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.Application
 
+import java.time.ZonedDateTime
+
 class ERSFileValidatorConnectorSpec extends PlaySpec with MockitoSugar with BeforeAndAfter with EitherValues with GuiceOneAppPerSuite {
 
   override lazy implicit val app: Application = GuiceApplicationBuilder().configure("metrics.enabled" -> false).build()
@@ -59,7 +60,7 @@ class ERSFileValidatorConnectorSpec extends PlaySpec with MockitoSugar with Befo
   val data: ListBuffer[Seq[String]] = ListBuffer[Seq[String]](Seq("abc"))
   val schemeInfo: SchemeInfo = SchemeInfo(
     schemeRef = "XA11000001231275",
-    timestamp = DateTime.now,
+    timestamp = ZonedDateTime.now,
     schemeId = "123PA12345678",
     taxYear = "2014/F15",
     schemeName = "MyScheme",

--- a/test/controllers/DataUploadControllerSpec.scala
+++ b/test/controllers/DataUploadControllerSpec.scala
@@ -26,7 +26,6 @@ import fixtures.WithMockedAuthActions
 import metrics.Metrics
 import models._
 import models.upscan.{UpscanCallback, UpscanCsvFileData, UpscanFileData}
-import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, eq => argEq}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
@@ -48,6 +47,8 @@ import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Futu
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.Application
 import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.time.ZonedDateTime
 
 class DataUploadControllerSpec extends TestKit(ActorSystem("DataUploadControllerSpec"))
   with AnyWordSpecLike with Matchers with OptionValues with MockitoSugar with GuiceOneAppPerSuite with WithMockedAuthActions with ScalaFutures {
@@ -79,7 +80,7 @@ class DataUploadControllerSpec extends TestKit(ActorSystem("DataUploadController
 
   val schemeInfo: SchemeInfo = SchemeInfo (
     schemeRef = "XA11000001231275",
-    timestamp = DateTime.now,
+    timestamp = ZonedDateTime.now,
     schemeId = "123PA12345678",
     taxYear = "2014/F15",
     schemeName = "MyScheme",

--- a/test/services/DataGeneratorSpec.scala
+++ b/test/services/DataGeneratorSpec.scala
@@ -19,7 +19,6 @@ package services
 import com.typesafe.config.ConfigFactory
 import config.ApplicationConfig
 import models.{ERSFileProcessingException, SchemeInfo}
-import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, eq => argEq}
 import org.mockito.Mockito._
 import org.scalatest.{BeforeAndAfter, EitherValues}
@@ -33,8 +32,9 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.services.validation.DataValidator
 import uk.gov.hmrc.services.validation.models.{Cell, Row, ValidationError}
 import utils.ErrorResponseMessages
-import scala.collection.immutable.ArraySeq
 
+import java.time.ZonedDateTime
+import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.util.Try
 
@@ -47,7 +47,7 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
 
   val schemeInfo: SchemeInfo = SchemeInfo(
     schemeRef = "XA11999991234567",
-    timestamp = DateTime.now,
+    timestamp = ZonedDateTime.now,
     schemeId = "123PA12345678",
     taxYear = "2014/F15",
     schemeName = "MyScheme",
@@ -149,24 +149,24 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
 
   "setValidator" should {
     "return a DataValidator if the given sheet name is valid" in {
-      assert(dataGenerator.setValidator("EMI40_Adjustments_V4")(SchemeInfo("", DateTime.now(), "" ,"" ,"", ""), hc, request).isInstanceOf[DataValidator])
+      assert(dataGenerator.setValidator("EMI40_Adjustments_V4")(SchemeInfo("", ZonedDateTime.now(), "" ,"" ,"", ""), hc, request).isInstanceOf[DataValidator])
     }
 
     "throw an exception if the given sheet name is not valid" in {
-      an[ERSFileProcessingException] mustBe thrownBy (dataGenerator.setValidator("Invalid")(SchemeInfo("", DateTime.now(), "" ,"" ,"", ""), hc, request))
+      an[ERSFileProcessingException] mustBe thrownBy (dataGenerator.setValidator("Invalid")(SchemeInfo("", ZonedDateTime.now(), "" ,"" ,"", ""), hc, request))
     }
   }
 
   "getValidatorAndSheetInfo" should {
     "return a Right with a DataValidator if the given sheet name is valid" in {
-      dataGenerator.getValidatorAndSheetInfo("EMI40_Adjustments_V4", SchemeInfo("", DateTime.now(), "" ,"" ,"", "")) match {
+      dataGenerator.getValidatorAndSheetInfo("EMI40_Adjustments_V4", SchemeInfo("", ZonedDateTime.now(), "" ,"" ,"", "")) match {
         case Left(_) => fail("Did not return validator")
         case Right(_) => succeed
       }
     }
 
     "return a left with an exception if the given sheet name is not valid" in {
-      dataGenerator.getValidatorAndSheetInfo("Invalid", SchemeInfo("", DateTime.now(), "" ,"" ,"", "")) match {
+      dataGenerator.getValidatorAndSheetInfo("Invalid", SchemeInfo("", ZonedDateTime.now(), "" ,"" ,"", "")) match {
         case Left(_) => succeed
         case Right(_) => fail("Did not return expected exception")
       }
@@ -187,7 +187,7 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
     "return an error when scheme types do not match" in {
       val schemeInfo2: SchemeInfo = SchemeInfo(
         schemeRef = "XA11999991234567",
-        timestamp = DateTime.now,
+        timestamp = ZonedDateTime.now,
         schemeId = "123PA12345678",
         taxYear = "2014/F15",
         schemeName = "MyScheme",
@@ -246,7 +246,7 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
     "get an exception if ods file has less than 9 rows and doesn't have header data" in {
       val schemeInfo: SchemeInfo = SchemeInfo (
         schemeRef = "XA11000001231275",
-        timestamp = DateTime.now,
+        timestamp = ZonedDateTime.now,
         schemeId = "123PA12345678",
         taxYear = "2014/F15",
         schemeName = "MyScheme",
@@ -261,7 +261,7 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
     "get an exception if ods file has more than 1 sheet but 1 of the sheets has less than 9 rows and doesn't have header data" in {
       val schemeInfo: SchemeInfo = SchemeInfo (
         schemeRef = "XA11000001231275",
-        timestamp = DateTime.now,
+        timestamp = ZonedDateTime.now,
         schemeId = "123PA12345678",
         taxYear = "2014/F15",
         schemeName = "MyScheme",
@@ -276,7 +276,7 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
     "get an exception if ods file doesn't contain any data" in {
       val schemeInfo: SchemeInfo = SchemeInfo (
         schemeRef = "XA11000001231275",
-        timestamp = DateTime.now,
+        timestamp = ZonedDateTime.now,
         schemeId = "123PA12345678",
         taxYear = "2014/F15",
         schemeName = "MyScheme",

--- a/test/services/ParserTest.scala
+++ b/test/services/ParserTest.scala
@@ -18,7 +18,6 @@ package services
 
 import config.ApplicationConfig
 import models.{ERSFileProcessingException, SchemeInfo}
-import org.joda.time.DateTime
 import org.scalatest.concurrent.{ScalaFutures, TimeLimits}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
@@ -28,6 +27,7 @@ import services.audit.AuditEvents
 import uk.gov.hmrc.http.HeaderCarrier
 import org.scalatest.{BeforeAndAfter, EitherValues}
 
+import java.time.ZonedDateTime
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.xml._
 
@@ -43,7 +43,7 @@ class ParserTest extends PlaySpec with ScalaFutures with MockitoSugar with Befor
 
   implicit val schemeInfo: SchemeInfo = SchemeInfo(
     schemeRef = "XA11999991234567",
-    timestamp = DateTime.now,
+    timestamp = ZonedDateTime.now,
     schemeId = "123PA12345678",
     taxYear = "2014/F15",
     schemeName = "MyScheme",

--- a/test/services/ProcessCsvServiceSpec.scala
+++ b/test/services/ProcessCsvServiceSpec.scala
@@ -28,7 +28,6 @@ import connectors.ERSFileValidatorConnector
 import helpers.MockProcessCsvService
 import models._
 import models.upscan.{UpscanCallback, UpscanCsvFileData}
-import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.OptionValues
@@ -44,6 +43,7 @@ import uk.gov.hmrc.services.validation.models.{Cell, Row, ValidationError}
 import utils.ErrorResponseMessages
 import org.scalatest.EitherValues
 
+import java.time.ZonedDateTime
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
@@ -65,7 +65,7 @@ class ProcessCsvServiceSpec extends TestKit(ActorSystem("Test")) with AnyWordSpe
 
   val schemeInfo: SchemeInfo = SchemeInfo(
     schemeRef = "XA11999991234567",
-    timestamp = DateTime.now,
+    timestamp = ZonedDateTime.now,
     schemeId = "123PA12345678",
     taxYear = "2014/F15",
     schemeName = "MyScheme",

--- a/test/services/ProcessOdsServiceSpec.scala
+++ b/test/services/ProcessOdsServiceSpec.scala
@@ -20,7 +20,6 @@ import config.ApplicationConfig
 import connectors.ERSFileValidatorConnector
 import models._
 import models.upscan.UpscanCallback
-import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, eq => argEq}
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfter
@@ -34,6 +33,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, SessionId}
 
 import java.io.{FileInputStream, FileOutputStream}
 import java.nio.file.Files
+import java.time.ZonedDateTime
 import java.util.zip.{ZipEntry, ZipOutputStream}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration.{Duration, SECONDS}
@@ -55,7 +55,7 @@ class ProcessOdsServiceSpec extends PlaySpec with CSVTestData with ScalaFutures 
 
   val schemeInfo: SchemeInfo = SchemeInfo (
     schemeRef = "XA11999991234567",
-    timestamp = DateTime.now,
+    timestamp = ZonedDateTime.now,
     schemeId = "123PA12345678",
     taxYear = "2014/F15",
     schemeName = "MyScheme",

--- a/test/services/audit/AuditEventsSpec.scala
+++ b/test/services/audit/AuditEventsSpec.scala
@@ -18,7 +18,6 @@ package services
 
 import models.{SchemeData, SchemeInfo}
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, eq => argEq}
 import org.mockito.Mockito.{times, verify}
 import org.scalatest.matchers.should.Matchers
@@ -32,12 +31,14 @@ import uk.gov.hmrc.services.validation.models._
 import scala.collection.mutable.ListBuffer
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import java.time.ZonedDateTime
+
 class AuditEventsSpec extends AnyWordSpecLike with Matchers with MockitoSugar {
 
   implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
   implicit var hc: HeaderCarrier = new HeaderCarrier()
   val mockAuditService: AuditService = mock[AuditService]
-  val dateTime = new DateTime
+  val dateTime = ZonedDateTime.now()
   val schemeInfo = new SchemeInfo("schemeRef",dateTime,"schemeID","taxYear","schemeName","schemeType")
   val schemeData = new SchemeData(schemeInfo,"sheetName", None, ListBuffer(Seq("")))
 

--- a/test/services/audit/AuditServiceSpec.scala
+++ b/test/services/audit/AuditServiceSpec.scala
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package services
+package services.audit
 
-import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.{any, eq => argEq}
 import org.mockito.Mockito._
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import services.audit.AuditService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditResult.Success
 import uk.gov.hmrc.play.audit.model.DataEvent
@@ -31,6 +29,8 @@ import uk.gov.hmrc.play.audit.model.DataEvent
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import org.scalatest.wordspec.AnyWordSpecLike
 import uk.gov.hmrc.play.audit.DefaultAuditConnector
+
+import java.time.ZonedDateTime
 
 class AuditServiceSpec extends AnyWordSpecLike with MockitoSugar with Matchers {
 
@@ -41,10 +41,10 @@ class AuditServiceSpec extends AnyWordSpecLike with MockitoSugar with Matchers {
     implicit val hc: HeaderCarrier = new HeaderCarrier
 
     implicit val ec: ExecutionContextExecutor = ExecutionContext.global
-    val dateTime = new DateTime
+    val dateTime = ZonedDateTime.now()
     val mockAuditConnector = mock[DefaultAuditConnector]
     val auditService = new AuditService(mockAuditConnector, ec) {
-      override protected def getDateTime: DateTime = dateTime
+      override protected def getDateTime: ZonedDateTime = dateTime
     }
     val details: Map[String, String] = Map("details1" -> "randomDetail")
 


### PR DESCRIPTION
# DDCE-5059

Removing dependency on Joda DateTime in favour of java.time.ZonedDateTime.

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date