### PR TITLE
DDCE-3441: Improve logging for setValidator and identifyAndDefineShee…

### DIFF
--- a/app/controllers/DataUploadController.scala
+++ b/app/controllers/DataUploadController.scala
@@ -61,7 +61,7 @@ class DataUploadController @Inject()(sessionService: SessionCacheService,
           }.recover {
             case e: ERSFileProcessingException =>
               deliverFileProcessingMetrics(startTime)
-              logger.warn(s"[DataUploadController][processFileDataFromFrontend] ERSFileProcessingException: ${e.getMessage}, context: ${e.context} schemeRef: ${schemeInfo.schemeRef}")
+              logger.warn(s"[DataUploadController][processFileDataFromFrontend] ERSFileProcessingException: ${e.getMessage}, context: ${e.context}, schemeRef: ${schemeInfo.schemeRef}")
               Accepted(e.message)
             case er: Exception =>
               deliverFileProcessingMetrics(startTime)

--- a/app/services/DataGenerator.scala
+++ b/app/services/DataGenerator.scala
@@ -142,7 +142,6 @@ class DataGenerator @Inject()(auditEvents: AuditEvents,
 
   def getSheetCsv(sheetName: String, schemeInfo: SchemeInfo)(
     implicit hc: HeaderCarrier, request: Request[_]): Either[Throwable, SheetInfo] = {
-    logger.debug(s"[DataGenerator][getSheetCsv] Looking for sheetName: $sheetName")
     ersSheetsConf(schemeInfo).get(sheetName) match {
       case Some(sheetInfo) => Right(sheetInfo)
       case _ =>
@@ -150,7 +149,7 @@ class DataGenerator @Inject()(auditEvents: AuditEvents,
         logger.warn("[DataGenerator][getSheetCsv] Couldn't identify SheetName")
         Left(ERSFileProcessingException(
           s"${ErrorResponseMessages.dataParserIncorrectSheetName}",
-          s"${ErrorResponseMessages.dataParserUnidentifiableSheetName(sheetName)}"))
+          s"${ErrorResponseMessages.dataParserUnidentifiableSheetNameContext}"))
     }
   }
 
@@ -190,13 +189,12 @@ class DataGenerator @Inject()(auditEvents: AuditEvents,
   }
 
   def getSheet(sheetName: String)(implicit schemeInfo: SchemeInfo, hc: HeaderCarrier, request: Request[_]): SheetInfo = {
-    logger.info(s"Looking for sheetName: $sheetName (schemeRef: ${schemeInfo.schemeRef})")
     ersSheetsConf(schemeInfo).getOrElse(sheetName, {
       auditEvents.fileProcessingErrorAudit(schemeInfo, sheetName, "Could not set the validator")
       logger.warn("[DataGenerator][getSheet] Couldn't identify SheetName")
       throw ERSFileProcessingException(
         s"${ErrorResponseMessages.dataParserIncorrectSheetName}",
-        s"${ErrorResponseMessages.dataParserUnidentifiableSheetName(sheetName)}")
+        s"${ErrorResponseMessages.dataParserUnidentifiableSheetNameContext}")
     })
   }
 

--- a/app/services/DataGenerator.scala
+++ b/app/services/DataGenerator.scala
@@ -34,6 +34,7 @@ import javax.inject.{Inject, Singleton}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
+import com.typesafe.config.ConfigException
 
 @Singleton
 class DataGenerator @Inject()(auditEvents: AuditEvents,
@@ -75,7 +76,10 @@ class DataGenerator @Inject()(auditEvents: AuditEvents,
         schemeData += SchemeData(schemeInfo, sheetName, None, ListBuffer())
         logger.info(s"SchemeData = ${schemeData.size} (schemeRef: ${schemeInfo.schemeRef}) ******")
         rowNum = 1
-        validator = setValidator(sheetName)
+        validator = getValidator(sheetName) match {
+          case Left(exception: ERSFileProcessingException) => throw exception
+          case Right(value: DataValidator) => value
+        }
       } else {
         rowData.map { rd =>
           (1 to rd._2).foreach { _ =>
@@ -112,17 +116,28 @@ class DataGenerator @Inject()(auditEvents: AuditEvents,
     schemeData
   }
 
-  def setValidator(sheetName: String)(implicit schemeInfo: SchemeInfo, hc: HeaderCarrier, request: Request[_]): DataValidator = {
-    try {
-      ERSValidationConfigs.getValidator(ersSheetsConf(schemeInfo)(sheetName).configFileName)
-    } catch {
-      case e: Exception =>
-        auditEvents.fileProcessingErrorAudit(schemeInfo, sheetName, "Could not set the validator")
-        logger.error("setValidator has thrown an exception. Exception message: " + e.getMessage)
-        throw ERSFileProcessingException(
-          s"${ErrorResponseMessages.dataParserConfigFailure}",
-          "Could not set the validator ")
-    }
+  private def getValidatorException(errorMsg: String): ERSFileProcessingException =
+    ERSFileProcessingException(
+      ErrorResponseMessages.dataParserConfigFailure,
+      errorMsg
+    )
+
+  def getValidator(sheetName: String)
+                  (implicit schemeInfo: SchemeInfo, hc: HeaderCarrier, request: Request[_]): Either[ERSFileProcessingException, DataValidator] = {
+      try {
+        Right(ERSValidationConfigs.getValidator(ersSheetsConf(schemeInfo)(sheetName).configFileName))
+      } catch {
+        case _: ConfigException.Missing =>
+          val errorMsg = "Could not set the validator due to a missing config"
+          auditEvents.fileProcessingErrorAudit(schemeInfo, sheetName, errorMsg)
+          logger.error(s"[getValidator] $errorMsg for sheet name: $sheetName and scheme type: ${schemeInfo.schemeType}.")
+          Left(getValidatorException(errorMsg))
+        case _: java.util.NoSuchElementException =>
+          val errorMsg = s"Sheet name: $sheetName does not match any for scheme types."
+          auditEvents.fileProcessingErrorAudit(schemeInfo, sheetName, errorMsg)
+          logger.error(s"[getValidator] $errorMsg")
+          Left(getValidatorException(errorMsg))
+      }
   }
 
   def getSheetCsv(sheetName: String, schemeInfo: SchemeInfo)(
@@ -156,15 +171,21 @@ class DataGenerator @Inject()(auditEvents: AuditEvents,
   def identifyAndDefineSheet(data: String)(implicit schemeInfo: SchemeInfo, hc: HeaderCarrier, request: Request[_]): String = {
     logger.debug("5.1  case 0 identifyAndDefineSheet  ")
     val res = getSheet(data)
-    if (res.schemeType.toLowerCase == schemeInfo.schemeType.toLowerCase) {
+    val schemeInfoSchemeType = schemeInfo.schemeType
+    val requestSchemeType = res.schemeType
+    if (requestSchemeType.toLowerCase == schemeInfoSchemeType.toLowerCase) {
       logger.debug("****5.1.1  data contains data:  *****" + data)
       data
     } else {
       auditEvents.fileProcessingErrorAudit(schemeInfo, data, s"${res.schemeType.toLowerCase} is not equal to ${schemeInfo.schemeType.toLowerCase}")
       logger.warn(ErrorResponseMessages.dataParserIncorrectSchemeType())
       throw ERSFileProcessingException(
-        s"${ErrorResponseMessages.dataParserIncorrectSchemeType()}",
-        s"${ErrorResponseMessages.dataParserIncorrectSchemeType(data)}")
+        s"${ErrorResponseMessages.dataParserIncorrectSheetName}",
+        s"${ErrorResponseMessages.dataParserIncorrectSchemeType(
+          Some(schemeInfoSchemeType),
+          Some(requestSchemeType)
+        )}"
+      )
     }
   }
 

--- a/app/services/ERSTemplatesInfo.scala
+++ b/app/services/ERSTemplatesInfo.scala
@@ -16,7 +16,7 @@
 
 package services
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 import services.ersTemplatesInfo._
 import uk.gov.hmrc.services.validation.DataValidator
 
@@ -80,7 +80,7 @@ object ERSValidationConfigs {
 
   val defValidator = new DataValidator(getConfig(ERSTemplatesInfo.emiSheet1ValConfig))
 
-  def getValidator(configName:String) = new DataValidator(getConfig(configName))
+  def getValidator(configName: String): DataValidator = new DataValidator(getConfig(configName))
 
-  def getConfig(sheetConfig:String) = ConfigFactory.load.getConfig(sheetConfig) //load new config per sheet on iteration
+  def getConfig(sheetConfig: String): Config = ConfigFactory.load.getConfig(sheetConfig) //load new config per sheet on iteration
 }

--- a/app/services/audit/AuditEvents.scala
+++ b/app/services/audit/AuditEvents.scala
@@ -27,7 +27,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class AuditEvents @Inject()(auditService: AuditService) {
 
-  def eventMap(schemeInfo: SchemeInfo, sheetName : String): Map[String, String] ={
+  def eventMap(schemeInfo: SchemeInfo, sheetName: String): Map[String, String] = {
     Map(
       "schemeRef" -> schemeInfo.schemeRef,
       "schemeType" -> schemeInfo.schemeType,
@@ -38,7 +38,8 @@ class AuditEvents @Inject()(auditService: AuditService) {
       "timestamp" -> schemeInfo.timestamp.toString)
   }
 
-  def auditRunTimeError(exception : Throwable, contextInfo : String, schemeInfo: SchemeInfo, sheetName : String) (implicit hc: HeaderCarrier,request: Request[_]) : Unit = {
+  def auditRunTimeError(exception: Throwable, contextInfo: String, schemeInfo: SchemeInfo, sheetName: String)
+                       (implicit hc: HeaderCarrier,request: Request[_]) : Unit = {
     auditService.sendEvent("ERSRunTimeError",Map(
       "ErrorMessage" -> exception.getMessage,
       "Context" -> contextInfo,
@@ -47,17 +48,18 @@ class AuditEvents @Inject()(auditService: AuditService) {
     ))
   }
 
-  def fileValidatorAudit(schemeInfo: SchemeInfo, sheetName : String)(implicit hc: HeaderCarrier,request: Request[_]): Boolean = {
+  def fileValidatorAudit(schemeInfo: SchemeInfo, sheetName: String)(implicit hc: HeaderCarrier, request: Request[_]): Boolean = {
     auditService.sendEvent("ERSFileValidatorAudit", eventMap(schemeInfo, sheetName))
     true
   }
 
-  def fileProcessingErrorAudit(schemeInfo: SchemeInfo, sheetName : String,errorMsg:String)(implicit hc: HeaderCarrier, request: Request[_]): Boolean = {
+  def fileProcessingErrorAudit(schemeInfo: SchemeInfo, sheetName: String, errorMsg: String)(implicit hc: HeaderCarrier, request: Request[_]): Boolean = {
     auditService.sendEvent("ERSFileProcessingError", eventMap(schemeInfo, sheetName) ++ Map("ErrorMessage" -> errorMsg))
     true
   }
 
-  def validationErrorAudit(validationErrors:List[ValidationError],schemeInfo: SchemeInfo, sheetName : String)(implicit hc: HeaderCarrier, request: Request[_]) = {
+  def validationErrorAudit(validationErrors:List[ValidationError], schemeInfo: SchemeInfo, sheetName: String)
+                          (implicit hc: HeaderCarrier, request: Request[_]): Boolean = {
     auditService.sendEvent("ERSValidationError",Map(
         "Column" -> validationErrors.head.cell.column,
         "Row" -> validationErrors.head.cell.row.toString,
@@ -67,7 +69,7 @@ class AuditEvents @Inject()(auditService: AuditService) {
     true
   }
 
-  def totalRows(totalRows : Int,schemeInfo: SchemeInfo)(implicit hc: HeaderCarrier, request: Request[_]): Boolean = {
+  def totalRows(totalRows: Int, schemeInfo: SchemeInfo)(implicit hc: HeaderCarrier, request: Request[_]): Boolean = {
 
     auditService.sendEvent("ERStotalRowCount", Map(
       "rows" -> totalRows.toString,

--- a/app/utils/ErrorResponseMessages.scala
+++ b/app/utils/ErrorResponseMessages.scala
@@ -18,7 +18,6 @@ package utils
 
 object ErrorResponseMessages {
 
-
   val fileProcessingServiceFailedStream = "Failed to stream the data from file"
   val fileProcessingServiceBulkEntity = "Exception bulk entity streaming"
   val fileValidatorConnectorFailedSendingData = "Failed sending data"
@@ -30,7 +29,14 @@ object ErrorResponseMessages {
   val dataParserFileParsingError = "Error while Parsing File"
   val dataParserParsingOfFileData = "Parsing of File Data"
   val dataParserIncorrectSheetName = "Incorrect ERS Template - Sheet Name isn't as expected"
-  def dataParserIncorrectSchemeType(data: String = "") = s"Incorrect ERS Template - Scheme Type isn't as expected $data"
+  def dataParserIncorrectSchemeType(expectedSheetName: Option[String] = None, parsedSheetName: Option[String] = None): String = {
+    (expectedSheetName, parsedSheetName) match {
+      case (Some(expectedSheet), Some(parsedSheet)) =>
+        s"Incorrect ERS Template - Scheme Type isn't as expected, expected: $expectedSheet parsed: $parsedSheet"
+      case (_, _) =>
+        "Incorrect ERS Template - Scheme Type isn't as expected"
+    }
+  }
   def dataParserUnidentifiableSheetName(sheetName: String = "") = s"Couldn't identify SheetName $sheetName"
   val dataParserIncorrectHeader = "Incorrect ERS Template - Header doesn't match"
   val dataParserHeadersDontMatch = "Header doesn't match"
@@ -40,6 +46,5 @@ object ErrorResponseMessages {
   val dataParserNoData = """The file that you chose doesn’t have any data after row 9. The reportable events data must start in cell A10.<br/><a href="https://www.gov.uk/government/collections/employment-related-securities">Use the ERS guidance documents</a> to help you create error-free files."""
   def ersCheckCsvFileNoData(sheetName: String = "") = "The file that you chose doesn’t contain any data.<br/>You won’t be able to upload " +
     s"$sheetName as part of your annual return."
-
 
 }

--- a/app/utils/ErrorResponseMessages.scala
+++ b/app/utils/ErrorResponseMessages.scala
@@ -37,7 +37,7 @@ object ErrorResponseMessages {
         "Incorrect ERS Template - Scheme Type isn't as expected"
     }
   }
-  def dataParserUnidentifiableSheetName(sheetName: String = "") = s"Couldn't identify SheetName $sheetName"
+  val dataParserUnidentifiableSheetNameContext = "Couldn't find config for given SheetName, sheet name may be incorrect"
   val dataParserIncorrectHeader = "Incorrect ERS Template - Header doesn't match"
   val dataParserHeadersDontMatch = "Header doesn't match"
   val dataParserFileInvalid = "File Invalid, formatting errors present"

--- a/test/services/DataGeneratorSpec.scala
+++ b/test/services/DataGeneratorSpec.scala
@@ -70,108 +70,73 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
       verify(mockAuditEvents, times(1)).fileProcessingErrorAudit(argEq(schemeInfo), argEq("csopHeaderSheet1Data"), argEq("Could not set the validator"))(any(), any())
     }
 
-    "validate CSOP_OptionsGranted_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(csopHeaderSheet1Data, "CSOP_OptionsGranted_V4")(schemeInfo, hc, request) must be(9)
-    }
-
-    "validate CSOP_OptionsRCL_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(csopHeaderSheet2Data, "CSOP_OptionsRCL_V4")(schemeInfo, hc, request) must be(9)
-    }
-
-    "validate CSOP_OptionsExercised_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(csopHeaderSheet3Data, "CSOP_OptionsExercised_V4")(schemeInfo, hc, request) must be(20)
-    }
-
-    "validate CSOP_OptionsGranted_V5 headerRow as valid" in {
-      when(mockAppConfig.csopV5Enabled).thenReturn(true)
-
-      dataGenerator.validateHeaderRow(csopHeaderSheet1DataV5, "CSOP_OptionsGranted_V5")(schemeInfo.copy(taxYear = "2023/24"), hc, request) must be(9)
-    }
-
-    "validate CSOP_OptionsRCL_V5 headerRow as valid" in {
-      when(mockAppConfig.csopV5Enabled).thenReturn(true)
-
-      dataGenerator.validateHeaderRow(csopHeaderSheet2Data, "CSOP_OptionsRCL_V5")(schemeInfo.copy(taxYear = "2023/24"), hc, request) must be(9)
-    }
-
-    "validate CSOP_OptionsExercised_V5 headerRow as valid" in {
-      when(mockAppConfig.csopV5Enabled).thenReturn(true)
-
-      dataGenerator.validateHeaderRow(csopHeaderSheet3Data, "CSOP_OptionsExercised_V5")(schemeInfo.copy(taxYear = "2023/24"), hc, request) must be(20)
-    }
-
-    "validate SIP_Awards_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(sipHeaderSheet1Data, "SIP_Awards_V4")(schemeInfo, hc, request) must be(17)
-    }
-
-    "validate SIP_Out_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(sipHeaderSheet2Data, "SIP_Out_V4")(schemeInfo, hc, request) must be(17)
-    }
-
-    "validate EMI40_Adjustments_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(emiHeaderSheet1Data, "EMI40_Adjustments_V4")(schemeInfo, hc, request) must be(14)
-    }
-
-    "validate EMI40_Replaced_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(emiHeaderSheet2Data, "EMI40_Replaced_V4")(schemeInfo, hc, request) must be(17)
-    }
-
-    "validate EMI40_RLC_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(emiHeaderSheet3Data, "EMI40_RLC_V4")(schemeInfo, hc, request) must be(12)
-    }
-
-    "validate EMI40_NonTaxable_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(emiHeaderSheet4Data, "EMI40_NonTaxable_V4")(schemeInfo, hc, request) must be(15)
-    }
-
-    "validate EMI40_Taxable_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(emiHeaderSheet5Data, "EMI40_Taxable_V4")(schemeInfo, hc, request) must be(20)
-    }
-
-    "validate Other_Grants_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet1Data, "Other_Grants_V4")(schemeInfo, hc, request) must be(4)
-    }
-
-    "validate Other_Options_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet2Data, "Other_Options_V4")(schemeInfo, hc, request) must be(42)
-    }
-
-    "validate Other_Acquisition_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet3Data, "Other_Acquisition_V4")(schemeInfo, hc, request) must be(40)
-    }
-
-    "validate Other_RestrictedSecurities_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet4Data, "Other_RestrictedSecurities_V4")(schemeInfo, hc, request) must be(20)
-    }
-
-    "validate Other_OtherBenefits_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet5Data, "Other_OtherBenefits_V4")(schemeInfo, hc, request) must be(13)
-    }
-
-    "validate Other_Convertible_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet6Data, "Other_Convertible_V4")(schemeInfo, hc, request) must be(15)
-    }
-
-    "validate Other_Notional_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet7Data, "Other_Notional_V4")(schemeInfo, hc, request) must be(13)
-    }
-
-    "validate Other_Enhancement_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet8Data, "Other_Enhancement_V4")(schemeInfo, hc, request) must be(14)
-    }
-
-    "validate Other_Sold_V4 headerRow as valid" in {
-      dataGenerator.validateHeaderRow(otherHeaderSheet9Data, "Other_Sold_V4")(schemeInfo, hc, request) must be(14)
+    // FIXME: Potentially add validator tests for SAYE header
+    Seq(
+      // V4 CSOP schemes
+      ("CSOP_OptionsGranted_V4", csopHeaderSheet1Data, 9, false),
+      ("CSOP_OptionsRCL_V4", csopHeaderSheet2Data, 9, false),
+      ("CSOP_OptionsExercised_V4", csopHeaderSheet3Data, 20, false),
+      // V5 CSOP schemes
+      ("CSOP_OptionsGranted_V5", csopHeaderSheet1DataV5, 9, true),
+      ("CSOP_OptionsRCL_V5", csopHeaderSheet2Data, 9, true),
+      ("CSOP_OptionsExercised_V5", csopHeaderSheet3Data, 20, true),
+      // SIP schemes
+      ("SIP_Awards_V4", sipHeaderSheet1Data, 17, false),
+      ("SIP_Out_V4", sipHeaderSheet2Data, 17, false),
+      // EMI schemes
+      ("EMI40_Adjustments_V4", emiHeaderSheet1Data, 14, false),
+      ("EMI40_Replaced_V4", emiHeaderSheet2Data, 17, false),
+      ("EMI40_RLC_V4", emiHeaderSheet3Data, 12, false),
+      ("EMI40_NonTaxable_V4", emiHeaderSheet4Data, 15, false),
+      ("EMI40_Taxable_V4", emiHeaderSheet5Data, 20, false),
+      // OTHER schemes
+      ("Other_Grants_V4", otherHeaderSheet1Data, 4, false),
+      ("Other_Options_V4", otherHeaderSheet2Data, 42, false),
+      ("Other_Acquisition_V4", otherHeaderSheet3Data, 40, false),
+      ("Other_RestrictedSecurities_V4", otherHeaderSheet4Data, 20, false),
+      ("Other_OtherBenefits_V4", otherHeaderSheet5Data, 13, false),
+      ("Other_Convertible_V4", otherHeaderSheet6Data, 15, false),
+      ("Other_Notional_V4", otherHeaderSheet7Data, 13, false),
+      ("Other_Enhancement_V4", otherHeaderSheet8Data, 14, false),
+      ("Other_Sold_V4", otherHeaderSheet9Data, 14, false),
+    ).foreach{
+      case (schemeName, headerData, headerSize, v5Scheme) =>
+        s"validate $schemeName headerRow as valid" in {
+          when(mockAppConfig.csopV5Enabled).thenReturn(v5Scheme)
+          val schemeInfoCorrectVersion = if (v5Scheme){
+            schemeInfo.copy(taxYear = "2023/24")
+          }
+          else {
+            schemeInfo
+          }
+          dataGenerator.validateHeaderRow(headerData, schemeName)(schemeInfoCorrectVersion, hc, request) must be(headerSize)
+        }
     }
   }
 
   "setValidator" should {
     "return a DataValidator if the given sheet name is valid" in {
-      assert(dataGenerator.setValidator("EMI40_Adjustments_V4")(SchemeInfo("", ZonedDateTime.now(), "", "2023/24", "", ""), hc, request).isInstanceOf[DataValidator])
+      val maybeDataValidator: Either[ERSFileProcessingException, DataValidator] =
+        dataGenerator.getValidator("EMI40_Adjustments_V4")(SchemeInfo("", ZonedDateTime.now(), "", "2023/24", "", ""), hc, request)
+      assert(maybeDataValidator.isRight)
     }
 
     "throw an exception if the given sheet name is not valid" in {
-      an[ERSFileProcessingException] mustBe thrownBy (dataGenerator.setValidator("Invalid")(SchemeInfo("", ZonedDateTime.now(), "" ,"" ,"", ""), hc, request))
+      dataGenerator.getValidator("Invalid")(SchemeInfo("", ZonedDateTime.now(), "" ,"" ,"", ""), hc, request)
+        .left
+        .map { (exception: ERSFileProcessingException) =>
+          assert(exception.message === "Failed to find the config file")
+          assert(exception.context === "Sheet name: Invalid does not match any for scheme types.")
+      }
+    }
+
+    "throw an exception if the given sheet name maps to a config file which does not exist" in {
+      dataGenerator.getValidator("CSOP_OptionsGranted_V4")(SchemeInfo("", ZonedDateTime.now(), "" ,"" ,"", ""), hc, request)
+        .left
+        .map { (exception: ERSFileProcessingException) =>
+          assert(exception.message === "Failed to find the config file")
+          assert(exception.context === "Could not set the validator due to a missing config.")
+        }
     }
   }
 
@@ -196,11 +161,24 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
       dataGenerator.identifyAndDefineSheet("EMI40_Adjustments_V4")(schemeInfo, hc, request) mustBe "EMI40_Adjustments_V4"
     }
 
-    "return an error when sheet name is invalid" in {
-      val result = Try(dataGenerator.identifyAndDefineSheet("EMI40_Adjustments")(schemeInfo, hc, request))
-      result.isFailure must be(true)
-      verify(mockAuditEvents, times(1)).fileProcessingErrorAudit(argEq(schemeInfo), argEq("EMI40_Adjustments"), argEq("Could not set the validator"))(any(), any())
+    "return an error indicating the sheet name indicating the sheet name isn't as expected" in {
+      val result: ERSFileProcessingException =
+        intercept[ERSFileProcessingException](dataGenerator.identifyAndDefineSheet("EMI40_Adjustments")(schemeInfo, hc, request))
+      assert(result.message === "Incorrect ERS Template - Sheet Name isn't as expected")
+      assert(result.context === "Couldn't identify SheetName EMI40_Adjustments")
+      verify(mockAuditEvents, times(1))
+        .fileProcessingErrorAudit(argEq(schemeInfo), argEq("EMI40_Adjustments"), argEq("Could not set the validator"))(any(), any())
     }
+
+  "return an error indicating the sheet type is not as expected" in {
+    val schemeInfoWithWrongSchemeType: SchemeInfo = schemeInfo.copy(schemeType = "CSOP")
+    val result: ERSFileProcessingException =
+      intercept[ERSFileProcessingException](dataGenerator.identifyAndDefineSheet("EMI40_Adjustments_V4")(schemeInfoWithWrongSchemeType, hc, request))
+    assert(result.message === "Incorrect ERS Template - Sheet Name isn't as expected")
+    assert(result.context === "Incorrect ERS Template - Scheme Type isn't as expected, expected: CSOP parsed: EMI")
+    verify(mockAuditEvents, times(1))
+      .fileProcessingErrorAudit(argEq(schemeInfoWithWrongSchemeType), argEq("EMI40_Adjustments_V4"), argEq("emi is not equal to csop"))(any(), any())
+  }
 
     "return an error when scheme types do not match" in {
       val schemeInfo2: SchemeInfo = SchemeInfo(

--- a/test/services/DataGeneratorSpec.scala
+++ b/test/services/DataGeneratorSpec.scala
@@ -165,7 +165,7 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
       val result: ERSFileProcessingException =
         intercept[ERSFileProcessingException](dataGenerator.identifyAndDefineSheet("EMI40_Adjustments")(schemeInfo, hc, request))
       assert(result.message === "Incorrect ERS Template - Sheet Name isn't as expected")
-      assert(result.context === "Couldn't identify SheetName EMI40_Adjustments")
+      assert(result.context === "Couldn't find config for given SheetName, sheet name may be incorrect")
       verify(mockAuditEvents, times(1))
         .fileProcessingErrorAudit(argEq(schemeInfo), argEq("EMI40_Adjustments"), argEq("Could not set the validator"))(any(), any())
     }
@@ -361,7 +361,7 @@ class DataGeneratorSpec extends PlaySpec with CSVTestData with ScalaFutures with
       assert(result.isLeft)
       result.swap.value mustBe ERSFileProcessingException(
         s"${ErrorResponseMessages.dataParserIncorrectSheetName}",
-        s"${ErrorResponseMessages.dataParserUnidentifiableSheetName("aWrongName")}")
+        s"${ErrorResponseMessages.dataParserUnidentifiableSheetNameContext}")
 
     }
   }

--- a/test/services/ParserTest.scala
+++ b/test/services/ParserTest.scala
@@ -91,7 +91,7 @@ class ParserTest extends PlaySpec with ScalaFutures with MockitoSugar with Befor
         }
       }
 
-      exceptionMessage mustBe "Incorrect ERS Template - Sheet Name isn't as expected, Couldn't identify SheetName EMI40_Taxable"
+      exceptionMessage mustBe "Incorrect ERS Template - Sheet Name isn't as expected, Couldn't find config for given SheetName, sheet name may be incorrect"
     }
 
     "display incorrectHeader exception in validateHeaderRow method" in {


### PR DESCRIPTION
- Improved the logging for three ODS submission scenarios:

1. Submitting a file with an incorrect sheet name, now produces the following log message:
```scala annotate 
[DataUploadController][processFileDataFromFrontend] ERSFileProcessingException: Incorrect ERS Template - Sheet Name isn't as expected, context: Couldn't find config for given SheetName, sheet name may be incorrect, schemeRef: XA1100000000000
```
(tested editing sheet name of existing ods)
  
2. Subbing a template which is different type to the option selected (e.g. `CSOP` submitted when `EMI` selected)
  ```scala annotate
[DataUploadController][processFileDataFromFrontend] ERSFileProcessingException: Incorrect ERS Template - Sheet Name isn't as expected, context: Incorrect ERS Template - Scheme Type isn't as expected, expected: CSOP parsed: EMI, schemeRef: XA1100000000000
```
(tested by selecting `CSOP` then submitting a valid `EMI` file)

  3. Submitting a file with there is no config folder for
  
  ```scala annotate
[DataUploadController][processFileDataFromFrontend] ERSFileProcessingException: Failed to find the config file, context: Could not set the validator due to a missing config, schemeRef: XA1100000000000
```

(deleted `CSOP` folder locally and then submitting a valid `CSOP` file)

- tidied up some tests, refactoring out a bunch of very similar tests