### PR TITLE
DDCE-2158: Improve row count logging for ODS and CSV files

### DIFF
--- a/app/services/ProcessOdsService.scala
+++ b/app/services/ProcessOdsService.scala
@@ -64,7 +64,7 @@ class ProcessOdsService @Inject()(dataGenerator: DataGenerator,
       val sessionId = hc.sessionId.getOrElse(SessionId(UUID.randomUUID().toString)).value
       sessionService.storeCallbackData(callbackData, totalRows)(RequestWithUpdatedSession(request, sessionId)).map {
         case Some(_) => {
-          logger.warn(s"Total rows for schemeRef ${schemeInfo.schemeRef}: $totalRows")
+          logger.info(s"[ProcessOdsService][processFile]: Total number of rows for ods file, schemeRef ${schemeInfo.schemeRef} (scheme type: ${schemeInfo.schemeType}): $totalRows")
           auditEvents.totalRows(totalRows, schemeInfo)
           res1
         }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion  = "9.5.0"
+  val bootstrapVersion  = "9.7.0"
   val pekkoVersion      = "1.0.2"
   val mongoVersion      = "2.3.0"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"         % "3.24.0")
 addSbtPlugin("com.github.gseitz"    % "sbt-release"            % "1.0.10")
-addSbtPlugin("org.playframework"    % "sbt-plugin"             % "3.0.5")
+addSbtPlugin("org.playframework"    % "sbt-plugin"             % "3.0.6")
 addSbtPlugin("org.scoverage"        % "sbt-scoverage"          % "2.2.1")
 addSbtPlugin("org.scalastyle"       %% "scalastyle-sbt-plugin" % "1.0.0" exclude ("org.scala-lang.modules", "scala-xml_2.12"))
 addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"     % "2.5.0")


### PR DESCRIPTION
# DDCE-2158

Update logging for ODS and CSV files row counts.

## Local Testing
Multiple  CSV files:
``` scala annotate
[DataUploadController][processCsvFileDataFromFrontendV2]: Total number of rows for csv file, schemeRef XA1100000000000 (scheme type: CSOP): 1
[DataUploadController][processCsvFileDataFromFrontendV2]: Total number of rows for csv file, schemeRef XA1100000000000 (scheme type: CSOP): 1
```
ODS file with multiple tabs:
``` scala annotate
[ProcessOdsService][processFile]: Total number of rows for ods file, schemeRef XA1100000000000 (scheme type: CSOP): 3
```
ODS file with single tab:
``` scala annotate
[ProcessOdsService][processFile]: Total number of rows for ods file, schemeRef XA1100000000000 (scheme type: CSOP): 1
```